### PR TITLE
Add AWS region and Github secrets support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ WORKDIR /
 RUN apk add jq
 
 COPY . .
-
+RUN chmod a+x ./entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ WORKDIR /
 RUN apk add jq
 
 COPY . .
-RUN chmod a+x ./entrypoint.sh
+RUN chmod a+x /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This action deploys ECS services using [fabfuel/ecs-deploy](https://github.com/f
 ```yml
 uses: brunocascio/ecs-deploy@v1.1.1
 with:
+  access_key: awsAccessKey
+  secret_key: awsSecretKey
   cluster: theClusterName
   service: theServiceName
   task: theTaskDefinitionName

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ with:
   service: theServiceName
   task: theTaskDefinitionName
   container: theContainerName
+  region: awsRegion
   envfile: /path/to/your/envfile (optionally)
   timeout: 720 (optionally, default 300)
 ```

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ uses: brunocascio/ecs-deploy@v1.1.1
 with:
   access_key: awsAccessKey
   secret_key: awsSecretKey
+  region: awsRegion
   cluster: theClusterName
   service: theServiceName
   task: theTaskDefinitionName
   container: theContainerName
-  region: awsRegion
   envfile: /path/to/your/envfile (optionally)
   timeout: 720 (optionally, default 300)
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This action deploys ECS services using [fabfuel/ecs-deploy](https://github.com/f
 ## Example usage
 
 ```yml
-uses: brunocascio/ecs-deploy@v1.1.1
+uses: brunocascio/ecs-deploy@v1.2.0
 with:
   access_key: awsAccessKey
   secret_key: awsSecretKey

--- a/action.yml
+++ b/action.yml
@@ -14,12 +14,15 @@ inputs:
     container:
         description: 'Container name to be updated'
         required: true
+    region:
+        description: 'Region to deploy in'
+        required: true
     envfile:
         description: 'Env file path'
         required: false
     timeout:
         description: 'Deployment timeout (default 300)'
-        required: false
+        required: false      
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -28,5 +31,6 @@ runs:
     - ${{ inputs.service }}
     - ${{ inputs.task }}
     - ${{ inputs.container }}
+    - ${{ inputs.region }}
     - ${{ inputs.envfile }}
     - ${{ inputs.timeout }}

--- a/action.yml
+++ b/action.yml
@@ -27,10 +27,12 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
+    - ${{ inputs.access_key }}
+    - ${{ inputs.secret_key }}
+    - ${{ inputs.region }}
     - ${{ inputs.cluster }}
     - ${{ inputs.service }}
     - ${{ inputs.task }}
     - ${{ inputs.container }}
-    - ${{ inputs.region }}
     - ${{ inputs.envfile }}
     - ${{ inputs.timeout }}

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 # action.yml
-name: 'ECS deploy'
+name: 'ECS deploy with Region'
 description: 'Github action using fabfuel/ecs-deploy script for ecs deployments'
 inputs:
     cluster:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,7 @@ set -e o pipefail
 [ -z "$INPUT_CONTAINER" ] && (echo "Missing Container Name" && exit 1)
 [ -z "$INPUT_TASK" ] && (echo "Missing Task Name" && exit 1)
 [ -z "$INPUT_SERVICE" ] && (echo "Missing Service Name" && exit 1)
+[ -z "$INPUT_REGION" ] && (echo "Missing Region" && exit 1)
 
 TIMEOUT=${INPUT_TIMEOUT:-300}
 
@@ -15,9 +16,9 @@ then
     [ ! -f $INPUT_ENVFILE ] && echo "$INPUT_ENVFILE not found" && exit 1 
     env_variables=$(grep -v '^#' "$INPUT_ENVFILE" | grep . | sed -E 's/=/ /1' | awk -v CONTAINER="$INPUT_CONTAINER" '{print "-e " CONTAINER " " $1 " " $2}')
     # make string command to be evaluated (one line string)
-    command=$(echo -n "ecs deploy $INPUT_CLUSTER $INPUT_SERVICE --timeout $TIMEOUT --task $INPUT_TASK $env_variables --exclusive-env")
+    command=$(echo -n "ecs deploy $INPUT_CLUSTER $INPUT_SERVICE --region $INPUT_REGION --timeout $TIMEOUT --task $INPUT_TASK $env_variables --exclusive-env")
 else
-    command=$(echo -n "ecs deploy $INPUT_CLUSTER $INPUT_SERVICE --timeout $TIMEOUT --task $INPUT_TASK")
+    command=$(echo -n "ecs deploy $INPUT_CLUSTER $INPUT_SERVICE --region $INPUT_REGION --timeout $TIMEOUT --task $INPUT_TASK")
 fi
 
 # fire command

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,8 @@ set -e o pipefail
 [ -z "$INPUT_TASK" ] && (echo "Missing Task Name" && exit 1)
 [ -z "$INPUT_SERVICE" ] && (echo "Missing Service Name" && exit 1)
 [ -z "$INPUT_REGION" ] && (echo "Missing Region" && exit 1)
+[ -z "$INPUT_ACCESS_KEY" ] && (echo "Missing Access Key" && exit 1)
+[ -z "$INPUT_SECRET_KEY" ] && (echo "Missing Access Key" && exit 1)
 
 TIMEOUT=${INPUT_TIMEOUT:-300}
 
@@ -18,7 +20,7 @@ then
     # make string command to be evaluated (one line string)
     command=$(echo -n "ecs deploy $INPUT_CLUSTER $INPUT_SERVICE --region $INPUT_REGION --timeout $TIMEOUT --task $INPUT_TASK $env_variables --exclusive-env")
 else
-    command=$(echo -n "ecs deploy $INPUT_CLUSTER $INPUT_SERVICE --region $INPUT_REGION --timeout $TIMEOUT --task $INPUT_TASK")
+    command=$(echo -n "ecs deploy $INPUT_CLUSTER $INPUT_SERVICE --access-key-id $INPUT_ACCESS_KEY --secret-access-key $INPUT_SECRET_KEY --region $INPUT_REGION --timeout $TIMEOUT --task $INPUT_TASK")
 fi
 
 # fire command


### PR DESCRIPTION
Hello,

I was having some issues using your Github action locally. fabfuel/ecs-deploy seems to require a region option whenever it is used in your Github action. as a result and due to my AWS config I have been unable to get your Github action to work in my ECS cluster.

I did find that fabfuel/ecs-deploy lets you explicitly set the AWS region in the command line. So I have updated your Github action to support the region option.. I have also added an option to set the AWS credentials explicitly in the config - this way Github secrets can be used to hide any sensitive credentials.

if you can review my PR it would be nice. let me know if I am missing anything.

thanks