### PR TITLE
Use new GitHub Actions output style

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh -le
 
 result=$(ecs $INPUT_ARGS)
+ret_code=$?
 
-echo "::set-output name=result::$result"
+echo result=$result >> $GITHUB_OUTPUT
+
+return $ret_code


### PR DESCRIPTION
Sorry, should've updated this as well.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/